### PR TITLE
Don't generate reports on master

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -1,0 +1,3 @@
+const { dupeReport } = require("./lib/index");
+
+dupeReport({ owner: "artsy", repo: "force", buildNum: 16867, dryRun: true });

--- a/src/api/circle.ts
+++ b/src/api/circle.ts
@@ -75,7 +75,7 @@ export class Circle {
       throw error;
     }
 
-    if (build.pull_requests.length > 0) {
+    if (build.pull_requests.length > 0 && build.branch !== "master") {
       return build.pull_requests[0].url;
     }
 


### PR DESCRIPTION
This is just a safe guard to ensure reports aren't generated on master. They _shouldn't_ be, and it would probably choke on something later, but this is just a little extra explicit. 