### PR TITLE
When exiting due to no diff, ensure a log is included

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -1,3 +1,8 @@
 const { dupeReport } = require("./lib/index");
 
-dupeReport({ owner: "artsy", repo: "force", buildNum: 16867, dryRun: true });
+dupeReport({
+  owner: "artsy",
+  repo: "force",
+  buildNum: 16872,
+  dryRun: true
+}).catch(err => console.error(err));

--- a/src/api/circle.ts
+++ b/src/api/circle.ts
@@ -76,7 +76,9 @@ export class Circle {
     }
 
     if (build.pull_requests.length > 0 && build.branch !== "master") {
-      return build.pull_requests[0].url;
+      const pr = build.pull_requests[0].url;
+      console.log("Related pull request:", pr);
+      return pr;
     }
 
     return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,8 +121,20 @@ export const dupeReport = async ({
 
   if (!hasDiff) {
     if (existingPRComment) {
-      await github.deleteComment(existingPRComment.id);
+      try {
+        await github.deleteComment(existingPRComment.id);
+      } catch (error) {
+        console.error(
+          `Failed to delete comment ${
+            existingPRComment.id
+          } in PR ${pullRequest}`,
+          error
+        );
+      }
     }
+    console.log(
+      `No change in build #${buildNum} in PR ${pullRequest}, exiting...`
+    );
     return;
   }
 


### PR DESCRIPTION
I was testing this out and it succeeded... but I didn't know it succeeded because nothing happened, heh. 