### PR TITLE
Don't send a slack message if the PR comment already exists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -168,6 +168,13 @@ export const dupeReport = async ({
     );
   }
 
+  if (existingPRComment) {
+    console.log(
+      `PR ${pullRequest} has likely already sent a slack notification, skipping...`
+    );
+    return;
+  }
+
   // Ping the designated slack channel that there are changes
 
   if (change > 0) {


### PR DESCRIPTION
If the PR comment already exists skip sending a message to slack. 