### PR TITLE
If dupes haven't changed but packages are updated don't report

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,17 +81,24 @@ export const dupeReport = async ({
   // Diff the reports
 
   let dupeDiff = "";
+  let headerDiff = false;
   let hasDiff = false;
   let change = 0;
 
   diffLines(masterReport.trim(), localReport.trim(), {
     newlineIsToken: true
-  }).forEach(line => {
+  }).forEach((line, lineNum) => {
     let lineStart = " ";
     if (line.added) {
+      if (lineNum <= 3) {
+        headerDiff = true;
+      }
       hasDiff = true;
       lineStart = "+";
     } else if (line.removed) {
+      if (lineNum <= 3) {
+        headerDiff = true;
+      }
       hasDiff = true;
       lineStart = "-";
     }
@@ -119,7 +126,7 @@ export const dupeReport = async ({
 
   // If there's no diff, remove the existing comment (if it exists) and quit
 
-  if (!hasDiff) {
+  if (!hasDiff || (change === 0 && !headerDiff)) {
     if (existingPRComment) {
       try {
         await github.deleteComment(existingPRComment.id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,13 +90,13 @@ export const dupeReport = async ({
   }).forEach((line, lineNum) => {
     let lineStart = " ";
     if (line.added) {
-      if (lineNum <= 3) {
+      if (lineNum <= 4) {
         headerDiff = true;
       }
       hasDiff = true;
       lineStart = "+";
     } else if (line.removed) {
-      if (lineNum <= 3) {
+      if (lineNum <= 4) {
         headerDiff = true;
       }
       hasDiff = true;


### PR DESCRIPTION
The "there's probably no change" case is happening often than I'd like. Specifically when a branch gets out of date from master which is no bueno. This isn't super smart, but if the header hasn't changed and there's a net 0 of overall diff changes just assume no change. 