### PR TITLE
Bail earlier when params are missing, remove defaults

### DIFF
--- a/packages/dupe-report/now.js
+++ b/packages/dupe-report/now.js
@@ -9,18 +9,19 @@ const { parse } = require("url");
 
 module.exports = (req, res) => {
   const { query } = parse(req.url, true);
-  const { owner = "artsy", repo = "force", buildNum, dryRun = false } = query;
+  const { owner, repo, buildNum, dryRun = false } = query;
+
+  if (!owner || !repo || !buildNum) {
+    res.writeHead(400);
+    res.end("Invalid params");
+  }
 
   let parsedOwner = String(owner);
   let parsedRepo = String(repo);
   let parsedDryRun = Boolean(dryRun);
   let parsedBuildNum = parseInt(buildNum);
 
-  if (
-    parsedBuildNum < 0 ||
-    parsedBuildNum === NaN ||
-    parsedBuildNum === Infinity
-  ) {
+  if (parsedBuildNum < 0 || parsedBuildNum === NaN || parsedBuildNum === Infinity) {
     return res.end("buildNum invalid");
   }
 


### PR DESCRIPTION
Some requests were getting through when buildNum wasn't defined, so this bails out a little earlier. Also it removes the defaults for `owner` and `repo` so it doesn't default to force. Also adds bails if those aren't present. 