### PR TITLE
Collapse existing duplicates to shorten message

### DIFF
--- a/packages/dupe-report/src/lib/format-report.ts
+++ b/packages/dupe-report/src/lib/format-report.ts
@@ -23,12 +23,16 @@ const changedMessaging = (change: number) => {
   const linesAdded =
     changeAmount === 0
       ? NO_CHANGE_MSG
-      : `Roughly <b>${changeAmount}</b> line${changeAmount === 1 ? "" : "s"} ${added ? "added" : "removed"}. `;
+      : `Roughly <b>${changeAmount}</b> line${changeAmount === 1 ? "" : "s"} ${
+          added ? "added" : "removed"
+        }. `;
 
   const changeTypeText =
     changeAmount === 0
       ? "There is likely no change."
-      : `This is probably a${added ? " <i>regression</i>" : "n <i>improvement</i>"} over master.`;
+      : `This is probably a${
+          added ? " <i>regression</i>" : "n <i>improvement</i>"
+        } over master.`;
 
   return linesAdded + " " + changeTypeText;
 };
@@ -57,7 +61,12 @@ const formatBody = (bodyData: BodyData[]) =>
     )
     .join("\n\n");
 
-export const formatReport = (report: string, diff: string, change: number, assignees: string[]) => {
+export const formatReport = (
+  report: string,
+  diff: string,
+  change: number,
+  assignees: string[]
+) => {
   let [header, bodyWithFooter] = splitAtLine(6, report);
   const [body] = splitAtLine(-6, bodyWithFooter);
 
@@ -70,7 +79,9 @@ export const formatReport = (report: string, diff: string, change: number, assig
     "[An introductory guide](https://github.com/FormidableLabs/inspectpack/#diagnosing-duplicates)\n";
 
   const bodyLines = body.split("\n");
-  const chunks = bodyLines.filter(line => line.match(chunkTitle)).map(chunk => "#" + chunk);
+  const chunks = bodyLines
+    .filter(line => line.match(chunkTitle))
+    .map(chunk => "#" + chunk);
 
   const chunkDependencies = body
     .split(chunkTitle)
@@ -103,6 +114,6 @@ export const formatReport = (report: string, diff: string, change: number, assig
     "\n\n" +
     "---" +
     "\n\n" +
-    formatBody(bodyData as BodyData[])
+    collapsible("Existing duplicates", formatBody(bodyData as BodyData[]))
   );
 };


### PR DESCRIPTION
This collapses the existing dependencies down into a details view so it doesn't push out the message so far. Most of the time folks don't care about that info, so there's no reason to have it taking up so much space. 

The other changes are just from prettier. 

<img width="746" alt="image" src="https://user-images.githubusercontent.com/3087225/71785539-aec2ec80-2fce-11ea-8144-a98a6b115459.png">
